### PR TITLE
3DCG 勉強会の試験休みを反映

### DIFF
--- a/schedule.js
+++ b/schedule.js
@@ -71,7 +71,7 @@ module.exports = [
     endTime: "",
     repeat: true,
     dayOfWeek: "2",
-    active: true,
+    active: false,
   },
   {
     name: "Rustを完全に理解する",


### PR DESCRIPTION
3DCG  勉強会は試験休みに入るので `schedule.js` で `active: false` にした。